### PR TITLE
Add missing elif statement in do_sync() function

### DIFF
--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -144,6 +144,9 @@ def do_sync(config, state, catalog):
         if stream['stream'] in EVENT_MAPPINGS.values():
             get_incremental_pull(stream, ENDPOINTS['metric'], state,
                                  api_key, start_date)
+        elif stream['stream'] in ADDITIONAL_PROPERTIES_KEYS:
+            get_incremental_pull_additional_properties(stream, ENDPOINTS['metric'], state,
+                                 api_key, start_date)
         elif stream['stream'] == 'list_members':
             if list_ids:
                 get_full_pulls(stream, ENDPOINTS[stream['stream']], api_key, list_ids)


### PR DESCRIPTION
The do_sync() function in init.py was missing an elif statement pertaining to ADDITIONAL_PROPERTY_KEYS